### PR TITLE
129 sort stats by year using a drop down

### DIFF
--- a/src/components/StatisticComponents/BarChart.vue
+++ b/src/components/StatisticComponents/BarChart.vue
@@ -21,7 +21,7 @@
       <p>Please select a subject from the list above</p>
     </div>
 
-    <div class="w-[70rem] mt-2" v-if="loaded && selectedSubject">
+    <div class="w-[70rem] mt-2" v-if="loaded && selectedSubject && selectedYear">
       <Bar :options="chartOptions" :data="getChartData" />
     </div>
 

--- a/src/components/StatisticComponents/BarChart.vue
+++ b/src/components/StatisticComponents/BarChart.vue
@@ -54,7 +54,6 @@ let years = storedYears.map((yearSelected)=> yearSelected.node.year);
 //if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 const stats = computed(()=>{ 
   if(selectedYear !== null){
-    console.log('yes')
     const indexSelectedYear = years.indexOf(selectedYear.value)
     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
 }

--- a/src/components/StatisticComponents/BarChart.vue
+++ b/src/components/StatisticComponents/BarChart.vue
@@ -54,6 +54,7 @@ let years = storedYears.map((yearSelected)=> yearSelected.node.year);
 //if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 const stats = computed(()=>{ 
   if(selectedYear !== null){
+    console.log('yes')
     const indexSelectedYear = years.indexOf(selectedYear.value)
     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
 }

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -35,24 +35,25 @@ ChartJS.register(ArcElement, Tooltip, Legend);
 const loaded = ref(true);
 const guidanceStore = useGuidanceStore();
 
-const selectedYear = ref('')
+const selectedYear = ref(2023)  
+// the code wont run unless there is a year selected at start
 const storedYears = guidanceStore.surveyStats.edges
 let years = storedYears.map((yearSelected)=> yearSelected.node.year);
 // console.log(selectedYear.value)  --> returns empty
 // if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
 const stats = computed(()=>{ 
-  if(selectedYear.value !== null){
-    console.log(selectedYear.value)     //empty
+  if(selectedYear !== null){
+    console.log(selectedYear.value)     // the year selected
     const indexSelectedYear = years.indexOf(selectedYear.value)
-    console.log(indexSelectedYear)      //returns -1
-    return JSON.parse(guidanceStore.surveyStats.edges[1].node.stats);
+    console.log(indexSelectedYear)      // the index of the selected year
+    return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
 } 
 })
 
 // const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
-const courses = Object.keys(stats.value); //returns each course name
 const selectedCourse = ref('');
+const courses = Object.keys(stats.value); //returns each course name
 
 const chartOptions = ref({
   responsive: true,
@@ -75,7 +76,7 @@ const getChartData = computed(() => { //use computed properties to recalculate o
     chartData.datasets[0].backgroundColor.push(randomColours)
   }
 
-  if (selectedCourse.value) {
+  if (selectedCourse.value && selectedYear.value) {
     const course = stats.value[selectedCourse.value];
     const ranks = course.ranks;
 

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -10,7 +10,6 @@
     <div v-if="!selectedYear" class="mt-2">
       <p>Please select a year from the list above</p>
     </div>
-   
     <!-- drop-down menu -->
     <select v-model="selectedCourse" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
       <option v-for="course in courses" :key="course" :value="course">{{ course }}</option>
@@ -35,24 +34,24 @@ ChartJS.register(ArcElement, Tooltip, Legend);
 
 const loaded = ref(true);
 const guidanceStore = useGuidanceStore();
-const selectedYear = ref('')
+let selectedYear = ref('')
 const storedYears = guidanceStore.surveyStats.edges
 let years = storedYears.map((yearSelected)=> yearSelected.node.year);
-
+console.log(selectedYear.value)
 // if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
-// const stats = computed(()=>{ 
-//   if(selectedYear.value !== null){
-//     const indexSelectedYear = years.indexOf(selectedYear.value)
-//     console.log(indexSelectedYear)
+const stats = computed(()=>{ 
+  if(selectedYear.value !== null){
+    console.log('yes')
+    const indexSelectedYear = years.indexOf(selectedYear)
+    console.log(indexSelectedYear.value)
+    return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
+} 
+})
 
-//     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
-// }
-// })
-
-const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
-console.log(stats)
+// const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
 const courses = Object.keys(stats); //returns each course name
+console.log(stats)
 const selectedCourse = ref('');
 
 const chartOptions = ref({

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -1,16 +1,17 @@
 <template>
   <div class="flex flex-col justify-center align-center items-center">
     <div class="text-2xl md:text-3xl font-semibold sm:flex text-center">Course Rankings</div>
-   
+    <!-- drop-down menu for years-->
     <select v-model="selectedYear" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
       <option v-for="year in years" :value="year" :key="year">
-        {{ year }}                                                                                                                                                                                                                                    
+        {{ year }}
       </option>
     </select>
+    <h1>{{ selectedYear }}</h1>
     <div v-if="!selectedYear" class="mt-2">
       <p>Please select a year from the list above</p>
     </div>
-    <!-- drop-down menu -->
+    <!-- drop-down menu for courses-->
     <select v-model="selectedCourse" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
       <option v-for="course in courses" :key="course" :value="course">{{ course }}</option>
     </select>
@@ -26,42 +27,35 @@
 <script lang="ts" setup>
 import { Pie } from 'vue-chartjs';
 import { useGuidanceStore } from '../../stores/guidance';
-import { ref, onMounted, computed, watch } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 const loaded = ref(true);
 const guidanceStore = useGuidanceStore();
-
-const selectedYear = ref(null)  
-// the code wont run unless there is a year selected at start
+const selectedCourse = ref('');
+const selectedYear = ref('')
 const storedYears = guidanceStore.surveyStats.edges
 let years = storedYears.map((yearSelected)=> yearSelected.node.year);
-// console.log(selectedYear.value)  --> returns empty
-// if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
-let stats = computed(()=>{ 
-  if(selectedYear.value !== null){
+// if a new year is selected from the dropdown, find the index where the stats are located and parse it into the stats
+const stats = computed(()=>{ 
+  if(selectedYear.value !== ''){
     const indexSelectedYear = years.indexOf(selectedYear.value)
+    console.log(selectedYear.value)
+    console.log(indexSelectedYear)
     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
-} 
+}
 })
-let selectedCourse = ref('');
 
-watch(selectedYear, (newSelectedYear) => {
-  if (newSelectedYear !== null) {
-    selectedCourse.value = null
-  }
-  })
-
-// const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
-const courses = computed(()=>{
-  if (stats.value) {
-    return Object.keys(stats.value); //returns each course name
-  }
-}) 
-
+ //returns each course name
+const courses = computed(() => {
+  //check if stats is defined before using Object.keys()
+  return stats.value ? Object.keys(stats.value) : [];
+ 
+});
+ 
 const chartOptions = ref({
   responsive: true,
 });
@@ -83,7 +77,7 @@ const getChartData = computed(() => { //use computed properties to recalculate o
     chartData.datasets[0].backgroundColor.push(randomColours)
   }
 
-  if (selectedCourse.value && selectedYear.value) {
+  if (selectedCourse.value) {
     const course = stats.value[selectedCourse.value];
     const ranks = course.ranks;
 

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -7,7 +7,7 @@
         {{ year }}
       </option>
     </select>
-    <h2>selected year: {{ selectedYear }}</h2>
+    <h1>{{ selectedYear }}</h1>
     <div v-if="!selectedYear" class="mt-2">
       <p>Please select a year from the list above</p>
     </div>
@@ -37,22 +37,21 @@ const guidanceStore = useGuidanceStore();
 
 const selectedYear = ref('')
 const storedYears = guidanceStore.surveyStats.edges
-const years = storedYears.map((yearSelected)=> yearSelected.node.year);
+let years = storedYears.map((yearSelected)=> yearSelected.node.year);
 // console.log(selectedYear.value)  --> returns empty
 // if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
 const stats = computed(()=>{ 
-  if(selectedYear.value !== ''){
-    console.log(selectedYear.value)
+  if(selectedYear.value !== null){
+    console.log(selectedYear.value)     //empty
     const indexSelectedYear = years.indexOf(selectedYear.value)
-    console.log(indexSelectedYear)
-    return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
+    console.log(indexSelectedYear)      //returns -1
+    return JSON.parse(guidanceStore.surveyStats.edges[1].node.stats);
 } 
 })
 
 // const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
-const courses = Object.keys(stats); //returns each course name
-console.log(stats)// --> returns undefined
+const courses = Object.keys(stats.value); //returns each course name
 const selectedCourse = ref('');
 
 const chartOptions = ref({
@@ -77,7 +76,7 @@ const getChartData = computed(() => { //use computed properties to recalculate o
   }
 
   if (selectedCourse.value) {
-    const course = stats[selectedCourse.value];
+    const course = stats.value[selectedCourse.value];
     const ranks = course.ranks;
 
     for (let i = 0; i < ranks.length; i++) {

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -7,7 +7,6 @@
         {{ year }}                                                                                                                                                                                                                                    
       </option>
     </select>
-    <h1>{{ selectedYear }}</h1>
     <div v-if="!selectedYear" class="mt-2">
       <p>Please select a year from the list above</p>
     </div>
@@ -27,7 +26,7 @@
 <script lang="ts" setup>
 import { Pie } from 'vue-chartjs';
 import { useGuidanceStore } from '../../stores/guidance';
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, watch } from 'vue';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -42,18 +41,23 @@ let years = storedYears.map((yearSelected)=> yearSelected.node.year);
 // console.log(selectedYear.value)  --> returns empty
 // if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
-const stats = computed(()=>{ 
+let stats = computed(()=>{ 
   if(selectedYear.value !== null){
     const indexSelectedYear = years.indexOf(selectedYear.value)
     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
 } 
 })
+let selectedCourse = ref('');
+
+watch(selectedYear, (newSelectedYear) => {
+  if (newSelectedYear !== null) {
+    selectedCourse.value = null
+  }
+  })
 
 // const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
-const selectedCourse = ref('');
 const courses = computed(()=>{
   if (stats.value) {
-    console.log(stats.value)
     return Object.keys(stats.value); //returns each course name
   }
 }) 

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -4,7 +4,7 @@
    
     <select v-model="selectedYear" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
       <option v-for="year in years" :value="year" :key="year">
-        {{ year }}
+        {{ year }}                                                                                                                                                                                                                                    
       </option>
     </select>
     <h1>{{ selectedYear }}</h1>
@@ -35,7 +35,7 @@ ChartJS.register(ArcElement, Tooltip, Legend);
 const loaded = ref(true);
 const guidanceStore = useGuidanceStore();
 
-const selectedYear = ref(2023)  
+const selectedYear = ref(null)  
 // the code wont run unless there is a year selected at start
 const storedYears = guidanceStore.surveyStats.edges
 let years = storedYears.map((yearSelected)=> yearSelected.node.year);
@@ -43,17 +43,20 @@ let years = storedYears.map((yearSelected)=> yearSelected.node.year);
 // if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
 const stats = computed(()=>{ 
-  if(selectedYear !== null){
-    console.log(selectedYear.value)     // the year selected
+  if(selectedYear.value !== null){
     const indexSelectedYear = years.indexOf(selectedYear.value)
-    console.log(indexSelectedYear)      // the index of the selected year
     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
 } 
 })
 
 // const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
 const selectedCourse = ref('');
-const courses = Object.keys(stats.value); //returns each course name
+const courses = computed(()=>{
+  if (stats.value) {
+    console.log(stats.value)
+    return Object.keys(stats.value); //returns each course name
+  }
+}) 
 
 const chartOptions = ref({
   responsive: true,

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -7,6 +7,7 @@
         {{ year }}
       </option>
     </select>
+    <h2>selected year: {{ selectedYear }}</h2>
     <div v-if="!selectedYear" class="mt-2">
       <p>Please select a year from the list above</p>
     </div>
@@ -14,7 +15,6 @@
     <select v-model="selectedCourse" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
       <option v-for="course in courses" :key="course" :value="course">{{ course }}</option>
     </select>
-
     <div class="w-[70rem] mt-2" v-if="loaded && selectedCourse && selectedYear">
       <Pie :options="chartOptions" :data="getChartData" />
     </div>
@@ -34,24 +34,25 @@ ChartJS.register(ArcElement, Tooltip, Legend);
 
 const loaded = ref(true);
 const guidanceStore = useGuidanceStore();
-let selectedYear = ref('')
+
+const selectedYear = ref('')
 const storedYears = guidanceStore.surveyStats.edges
-let years = storedYears.map((yearSelected)=> yearSelected.node.year);
-console.log(selectedYear.value)
+const years = storedYears.map((yearSelected)=> yearSelected.node.year);
+// console.log(selectedYear.value)  --> returns empty
 // if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
 
 const stats = computed(()=>{ 
-  if(selectedYear.value !== null){
-    console.log('yes')
-    const indexSelectedYear = years.indexOf(selectedYear)
-    console.log(indexSelectedYear.value)
+  if(selectedYear.value !== ''){
+    console.log(selectedYear.value)
+    const indexSelectedYear = years.indexOf(selectedYear.value)
+    console.log(indexSelectedYear)
     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
 } 
 })
 
 // const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
 const courses = Object.keys(stats); //returns each course name
-console.log(stats)
+console.log(stats)// --> returns undefined
 const selectedCourse = ref('');
 
 const chartOptions = ref({

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -1,12 +1,22 @@
 <template>
   <div class="flex flex-col justify-center align-center items-center">
     <div class="text-2xl md:text-3xl font-semibold sm:flex text-center">Course Rankings</div>
+   
+    <select v-model="selectedYear" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
+      <option v-for="year in years" :value="year" :key="year">
+        {{ year }}
+      </option>
+    </select>
+    <div v-if="!selectedYear" class="mt-2">
+      <p>Please select a year from the list above</p>
+    </div>
+   
     <!-- drop-down menu -->
     <select v-model="selectedCourse" class="space rounded-md border border-solid border-zinc-400 h-10 p-2 mt-2 w-80">
       <option v-for="course in courses" :key="course" :value="course">{{ course }}</option>
     </select>
 
-    <div class="w-[70rem] mt-2" v-if="loaded && selectedCourse">
+    <div class="w-[70rem] mt-2" v-if="loaded && selectedCourse && selectedYear">
       <Pie :options="chartOptions" :data="getChartData" />
     </div>
     <div v-else class="mt-2">
@@ -25,7 +35,23 @@ ChartJS.register(ArcElement, Tooltip, Legend);
 
 const loaded = ref(true);
 const guidanceStore = useGuidanceStore();
+const selectedYear = ref('')
+const storedYears = guidanceStore.surveyStats.edges
+let years = storedYears.map((yearSelected)=> yearSelected.node.year);
+
+// if a new year is selected from the dropdown, find the index where the stats are located and parse it into the
+
+// const stats = computed(()=>{ 
+//   if(selectedYear.value !== null){
+//     const indexSelectedYear = years.indexOf(selectedYear.value)
+//     console.log(indexSelectedYear)
+
+//     return JSON.parse(guidanceStore.surveyStats.edges[indexSelectedYear].node.stats);
+// }
+// })
+
 const stats = JSON.parse(guidanceStore.surveyStats.edges[0].node.stats);
+console.log(stats)
 const courses = Object.keys(stats); //returns each course name
 const selectedCourse = ref('');
 

--- a/src/components/StatisticComponents/PieChart.vue
+++ b/src/components/StatisticComponents/PieChart.vue
@@ -7,7 +7,6 @@
         {{ year }}
       </option>
     </select>
-    <h1>{{ selectedYear }}</h1>
     <div v-if="!selectedYear" class="mt-2">
       <p>Please select a year from the list above</p>
     </div>


### PR DESCRIPTION
Fixed the years in the bar and pie chart. The only thing is that you can't directly compare the same courses across different years without having to empty the entire graph. For example, if you select a new year, the courses will instantly be redefined to null and you need to choose a new course to push data into the graph.